### PR TITLE
feat: Robo de carta implementado

### DIFF
--- a/src/main/java/org/springframework/samples/notimeforheroes/game/GameController.java
+++ b/src/main/java/org/springframework/samples/notimeforheroes/game/GameController.java
@@ -438,6 +438,19 @@ public class GameController {
         return "redirect:/games/board/"+gameId;
     }
 
+    @GetMapping("/board/{gameId}/stealCard")
+    public String stealCard(@PathVariable("gameId") int gameId){
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+	    String currentUserName = auth.getName();
+	    User currentUser = userService.findByUsername(currentUserName);
+
+        service.stealCard(service.getCurrentPlayer(currentUser, gameId));
+
+        return "redirect:/games/board/"+gameId;
+    }
+
+
+
 
 
 

--- a/src/main/java/org/springframework/samples/notimeforheroes/game/GameService.java
+++ b/src/main/java/org/springframework/samples/notimeforheroes/game/GameService.java
@@ -1,6 +1,8 @@
 package org.springframework.samples.notimeforheroes.game;
 
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
@@ -190,6 +192,44 @@ public class GameService {
 
 
     }
-    
+
+    public void stealCard(Player player){
+        List<AbilityCardInGame> pile = player.getAbilityPile();
+        List<AbilityCardInGame> hand = player.getAbilityHand();
+        List<AbilityCardInGame> discards= player.getDiscardPile();
+
+        if(pile.size()==0){
+            pile = discards;
+            Collections.shuffle(pile);
+            for(int i = 0; i<pile.size(); i++){
+                pile.get(i).setPlayerDiscard(null);
+                // pile.get(i).setPlayer(null);
+                pile.get(i).setPlayerPile(player);
+                System.out.println("Cartas en descarte: "+pile.get(i).getPlayerPile());
+                // discards.remove(c);
+                abilityService.saveAbilityCardInGame(pile.get(i));
+                
+            }
+            // player.setAbilityPile(pile);
+            // player.setDiscardPile(discards);
+
+
+
+            playerService.savePlayer(player);
+        }
+
+        AbilityCardInGame card = pile.get(0);
+        card.setPlayer(player);
+        card.setPlayerPile(null);
+
+        pile.remove(card);
+        hand.add(card);
+        
+        abilityService.saveAbilityCardInGame(card);
+        playerService.savePlayer(player);
+
+
+
+    }
 
 }

--- a/src/main/webapp/WEB-INF/jsp/games/board.jsp
+++ b/src/main/webapp/WEB-INF/jsp/games/board.jsp
@@ -171,9 +171,13 @@
 					
 					<h4 class="pilaDesgaste">PilaDesgaste</h4>
 				</div>
+				
 				<div class="myCard baraja">
-					<img
-						src="<spring:url value="/resources/images/no-time-for-heroes.png" htmlEscape="true" />">
+					<c:if test="${player.abilityPile.size() >0}">
+						<img
+						src="/resources/images/Cards/Abilities/${player.abilityPile.get(0).abilityCard.abilityType}.jpg">
+					</c:if>
+					
 					<h4 class="baraja">Baraja</h4>
 					
 				</div>


### PR DESCRIPTION
Se accede mediante /games/board/1/stealCard.

Roba una carta del mazo, y en caso de que no haya mazo, coge la pila de desgaste y la baraja para ponerla de mazo